### PR TITLE
feat: add mlship benchmark command for model performance measurement

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -140,11 +140,40 @@ mlship/
 │   ├── pytorch.py      # PyTorch loader
 │   ├── tensorflow.py   # TensorFlow/Keras loader
 │   └── huggingface.py  # HuggingFace Transformers loader
+├── benchmark.py        # Performance benchmarking engine
 ├── pipeline.py         # Custom pre/post processing
 ├── models.py           # Pydantic request/response models
 ├── errors.py           # Custom exceptions
 └── utils.py            # Helper utilities
 ```
+
+### Benchmark Flow
+
+1. **CLI** (`mlship benchmark model.pkl`)
+   - Detects framework from file extension
+   - Starts model server in a background process (`multiprocessing.Process`)
+   - Waits for server readiness (polls `/health` endpoint, 30s timeout)
+
+2. **Cold Start Measurement**
+   - Times the first prediction request after server startup
+   - Captures model initialization + first inference overhead
+
+3. **Warmup Phase**
+   - Runs configurable warmup requests (default: 5)
+   - Primes caches and JIT compilation paths
+
+4. **Benchmark Phase**
+   - Runs configurable number of requests (default: 100)
+   - Records per-request latency in milliseconds
+   - Calculates statistics: avg, min, p50, p95, p99, max, throughput (RPS)
+
+5. **Cleanup**
+   - Gracefully terminates background server process
+   - Falls back to kill if terminate times out (5s)
+
+6. **Output**
+   - Text format: human-readable table to stdout
+   - JSON format: machine-parseable for CI/CD (`--output json`)
 
 ### Request Flow
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -663,58 +663,270 @@ sudo apt install python3.12 python3.12-venv
 
 ---
 
+## Contributing Checklist
+
+**For Contributors:** Before submitting a pull request, complete this checklist:
+
+### 1. Code Changes
+
+- [ ] **Write/Update Tests**
+  - Add test cases for new features in `tests/`
+  - Update existing tests if behavior changed
+  - Ensure test coverage for edge cases
+
+- [ ] **Run Regression Tests**
+  ```bash
+  source .venv/bin/activate
+  pytest tests/ -v
+  ```
+  All existing tests must pass.
+
+- [ ] **Run Code Quality Checks**
+  ```bash
+  # Format code
+  black mlship/ tests/
+
+  # Lint code
+  ruff check --fix mlship/ tests/
+
+  # Type check (optional but recommended)
+  mypy mlship/
+  ```
+
+- [ ] **Test Manually**
+  - Test your changes with real models
+  - Verify error messages are helpful
+  - Check edge cases
+
+### 2. Documentation
+
+- [ ] **Update Documentation**
+  - Update `README.md` if adding new feature
+  - Update `QUICKSTART.md` with examples if user-facing
+  - Update `CONTRIBUTING.md` if changing workflow
+  - Add docstrings to new functions/classes
+
+- [ ] **Update CHANGELOG** (if exists)
+  - Add entry describing your changes
+
+### 3. Submit Pull Request
+
+- [ ] **Create Feature Branch**
+  ```bash
+  git checkout -b feature/your-feature-name
+  ```
+
+- [ ] **Commit with Clear Messages**
+  ```bash
+  git commit -m "feat: add benchmark command"
+  git commit -m "fix: resolve model loading issue"
+  git commit -m "docs: update quickstart guide"
+  ```
+
+- [ ] **Push Branch**
+  ```bash
+  git push origin feature/your-feature-name
+  ```
+
+- [ ] **Open Pull Request**
+  - Describe what your PR does
+  - Reference related issues (e.g., "Closes #123")
+  - Add screenshots/examples if relevant
+
+### 4. After PR Submission
+
+- [ ] **Wait for CI to Pass**
+  - GitHub Actions will run tests automatically
+  - Fix any failures before requesting review
+
+- [ ] **Address Review Comments**
+  - Respond to reviewer feedback
+  - Make requested changes
+  - Push updates to same branch
+
+- [ ] **Merge**
+  - Maintainer will merge after approval
+  - Delete your feature branch after merge
+
+**Quick Pre-PR Command:**
+```bash
+# Run all checks at once
+./pre_push.sh
+```
+
+---
+
 ## Release Process
 
-(For maintainers)
+**For Maintainers:** Publishing a new version to PyPI
 
-1. **Update version** in `pyproject.toml` and `mlship/__init__.py`
-   ```bash
-   # Change version line: version = "0.1.2"
-   git add pyproject.toml mlship/__init__.py
-   git commit -m "chore: bump version to 0.1.2"
-   ```
+### Pre-Release Checklist
 
-2. **Clean and build package**
-   ```bash
-   rm -rf dist/ build/ *.egg-info
-   python -m build
-   ```
+Before starting the release:
 
-3. **Test installation locally**
-   ```bash
-   uv pip install dist/mlship-0.1.2-py3-none-any.whl
-   mlship --version
-   ```
-Note: change the version number accordingly.
-4. **Test on TestPyPI first** ⚠️ **Important: Don't skip this!**
-   ```bash
-   twine upload --repository testpypi dist/*
-   # Test install from TestPyPI
-   pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple mlship
-   ```
+- [ ] All tests passing on `main` branch
+- [ ] All PRs for this release are merged
+- [ ] CHANGELOG updated (if exists)
+- [ ] Documentation updated for new features
 
-5. **Publish to PyPI** (only after TestPyPI works)
-   ```bash
-   twine upload dist/*
-   ```
+### Release Steps
 
-6. **Run post-release smoke test** ⚠️ **Critical: Validates the PyPI package**
-   ```bash
-   # Test the latest published version
-   ./scripts/post_release_smoke_test.sh
+#### 1. Update Version Numbers
 
-   # Or test a specific version
-   ./scripts/post_release_smoke_test.sh 0.1.5
-   ```
+Update version in **two files**:
 
-   This creates a fresh environment, installs from PyPI, and validates all QUICKSTART examples work correctly.
+**`pyproject.toml`:**
+```toml
+version = "0.2.0"
+```
 
-7. **Create git tag and push**
-   ```bash
-   git tag v0.1.2
-   git push origin main --tags
-   ```
-   Note: change tag versions accordingly
+**`mlship/__init__.py`:**
+```python
+__version__ = "0.2.0"
+```
+
+Commit the changes:
+```bash
+git add pyproject.toml mlship/__init__.py
+git commit -m "chore: bump version to 0.2.0"
+git push origin main
+```
+
+#### 2. Build Package
+
+```bash
+# Clean old builds
+rm -rf dist/ build/ *.egg-info
+
+# Build
+python -m build
+```
+
+Verify the build:
+```bash
+ls -lh dist/
+# Should show: mlship-0.2.0-py3-none-any.whl and mlship-0.2.0.tar.gz
+```
+
+#### 3. Test Installation Locally
+
+```bash
+# Install from wheel
+pip install dist/mlship-0.2.0-py3-none-any.whl
+
+# Verify version
+mlship --version
+# Should output: mlship version 0.2.0
+
+# Quick functionality test
+mlship --help
+```
+
+#### 4. Test on TestPyPI (Optional but Recommended)
+
+⚠️ **Recommended for major releases:**
+
+```bash
+# Upload to TestPyPI
+twine upload --repository testpypi dist/*
+
+# Test install from TestPyPI
+pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple mlship
+
+# Test it works
+mlship --version
+```
+
+#### 5. Publish to PyPI
+
+**This is irreversible! Double-check everything.**
+
+```bash
+twine upload dist/*
+```
+
+Wait 2-3 minutes for PyPI CDN propagation.
+
+#### 6. Run Post-Release Smoke Test
+
+⚠️ **Critical: Validates the published package**
+
+```bash
+# Test the latest version from PyPI
+./scripts/post_release_smoke_test.sh
+
+# Or test specific version
+./scripts/post_release_smoke_test.sh 0.2.0
+```
+
+This validates:
+- Package installs correctly from PyPI
+- All frameworks work (sklearn, PyTorch, TensorFlow, HuggingFace)
+- All QUICKSTART examples work
+- No import errors or missing dependencies
+
+**If smoke test fails:** The package is already published but broken. Immediately:
+1. Fix the issue
+2. Bump to patch version (e.g., 0.2.0 → 0.2.1)
+3. Republish
+
+#### 7. Create Git Tag
+
+```bash
+# Create annotated tag
+git tag -a v0.2.0 -m "Release v0.2.0: Add benchmark command"
+
+# Push tag to GitHub
+git push origin v0.2.0
+```
+
+#### 8. Create GitHub Release
+
+1. Go to: https://github.com/sudhanvalabs/mlship/releases/new
+2. Select tag: `v0.2.0`
+3. Release title: `v0.2.0 - Benchmark Command`
+4. Description (example):
+
+```markdown
+## What's New
+
+- 🎯 **Benchmark Command**: Measure model serving performance with `mlship benchmark`
+  - Latency metrics (avg, p50, p95, p99)
+  - Throughput measurement
+  - JSON output for automation
+  - Works with all frameworks
+
+## Installation
+
+```bash
+pip install mlship
+```
+
+## Full Changelog
+
+- feat: add benchmark command (#1)
+- fix: improve PyTorch model loading
+- docs: enhance quickstart guide
+
+**Full Changelog**: https://github.com/sudhanvalabs/mlship/compare/v0.1.5...v0.2.0
+```
+
+5. Click "Publish release"
+
+### Post-Release
+
+- [ ] Announce on LinkedIn/Twitter
+- [ ] Update any related blog posts
+- [ ] Close milestone (if using GitHub milestones)
+- [ ] Thank contributors
+
+### Version Numbering
+
+Follow [Semantic Versioning](https://semver.org/):
+
+- **Major** (1.0.0): Breaking changes
+- **Minor** (0.2.0): New features, backward compatible
+- **Patch** (0.1.6): Bug fixes, backward compatible
 
 For detailed publishing instructions, see [PUBLISHING.md](PUBLISHING.md).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,7 +109,7 @@ pytest
 
 ### Run Integration Tests Only
 
-These tests download models, test all API endpoints, and cleanup automatically:
+**API Integration Tests** - Test FastAPI endpoints directly:
 
 ```bash
 pytest tests/test_integration.py -v
@@ -127,6 +127,48 @@ Each test:
 3. Tests all endpoints: `/health`, `/info`, `/predict`, `/docs`
 4. Tests error handling
 5. Cleans up (deletes downloaded models)
+
+**CLI Integration Tests** - Test actual CLI commands (serve, benchmark):
+
+```bash
+pytest tests/test_cli_integration.py -v
+```
+
+This tests:
+- ✅ `mlship serve` command with sklearn, PyTorch, TensorFlow, HuggingFace models
+- ✅ `mlship benchmark` command with all model types
+- ✅ Custom payloads and output formats
+- ✅ End-to-end CLI workflow
+
+### Run Framework-Specific Tests
+
+Test only specific frameworks (if you don't have all dependencies installed):
+
+```bash
+# Test only sklearn
+pytest tests/test_cli_integration.py::TestServeCommandCLI::test_serve_sklearn_cli -v
+
+# Test only PyTorch
+pytest tests/test_cli_integration.py::TestServeCommandCLI::test_serve_pytorch_cli -v
+
+# Test only TensorFlow
+pytest tests/test_cli_integration.py::TestServeCommandCLI::test_serve_tensorflow_cli -v
+
+# Test benchmarking
+pytest tests/test_cli_integration.py::TestBenchmarkCommandCLI -v
+```
+
+### Skip Slow Tests
+
+HuggingFace Hub tests download models (~268MB) and are marked as slow:
+
+```bash
+# Skip slow tests
+pytest -m "not slow"
+
+# Run only slow tests
+pytest -m "slow"
+```
 
 ### Run with Coverage
 
@@ -204,25 +246,44 @@ pytest tests/ -v
 # Test core loaders (sklearn, PyTorch, TensorFlow, HuggingFace)
 pytest tests/test_loaders.py -v
 
-# Test CLI commands
+# Test CLI commands (unit tests)
 pytest tests/test_cli.py -v
 
-# Test end-to-end integration
+# Test API endpoints (FastAPI integration)
 pytest tests/test_integration.py -v
+
+# Test CLI commands with real models (end-to-end)
+pytest tests/test_cli_integration.py -v
 
 # Test benchmark functionality
 pytest tests/test_benchmark.py -v
 ```
 
+**Comprehensive framework coverage testing:**
+```bash
+# Test all frameworks with actual CLI commands
+pytest tests/test_cli_integration.py -v
+
+# This tests:
+# - mlship serve with sklearn, PyTorch, TensorFlow, HuggingFace models
+# - mlship benchmark with all model types
+# - Custom payloads and output formats
+# - Full end-to-end workflows
+```
+
 **With coverage report:**
 ```bash
 pytest tests/ -v --cov=mlship --cov-report=term-missing
+
+# Or for HTML report
+pytest tests/ --cov=mlship --cov-report=html
 ```
 
 This ensures:
 - ✅ All model loaders still work (sklearn, PyTorch, TensorFlow, HuggingFace)
-- ✅ CLI commands work correctly
+- ✅ CLI commands work correctly (both unit and integration tests)
 - ✅ Server endpoints function properly
+- ✅ Benchmark command works with all model types
 - ✅ Error handling is intact
 - ✅ No breaking changes introduced
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -185,6 +185,56 @@ black --check mlship/ tests/
 ruff check mlship/ tests/
 ```
 
+### Regression Testing
+
+When adding new features or making changes, run regression tests to ensure existing functionality still works:
+
+**Full regression test suite:**
+```bash
+# Activate virtual environment first
+source .venv/bin/activate  # macOS/Linux
+.venv\Scripts\activate     # Windows
+
+# Run all tests
+pytest tests/ -v
+```
+
+**Test specific areas:**
+```bash
+# Test core loaders (sklearn, PyTorch, TensorFlow, HuggingFace)
+pytest tests/test_loaders.py -v
+
+# Test CLI commands
+pytest tests/test_cli.py -v
+
+# Test end-to-end integration
+pytest tests/test_integration.py -v
+
+# Test benchmark functionality
+pytest tests/test_benchmark.py -v
+```
+
+**With coverage report:**
+```bash
+pytest tests/ -v --cov=mlship --cov-report=term-missing
+```
+
+This ensures:
+- ✅ All model loaders still work (sklearn, PyTorch, TensorFlow, HuggingFace)
+- ✅ CLI commands work correctly
+- ✅ Server endpoints function properly
+- ✅ Error handling is intact
+- ✅ No breaking changes introduced
+
+**Example workflow when adding a feature:**
+1. Create feature branch
+2. Implement feature
+3. Write tests for new feature
+4. Run regression tests: `pytest tests/ -v`
+5. Fix any broken tests
+6. Run pre-push checks: `./pre_push.sh`
+7. Commit and push
+
 ### GitHub Actions (Automated Testing)
 
 mlship uses GitHub Actions to automatically test on **every push** across:

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -416,6 +416,95 @@ mlship serve model.pkl --name "fraud-detector"
 
 ---
 
+## Benchmarking Your Model
+
+mlship includes a built-in benchmark command to measure model serving performance.
+
+### Basic Benchmarking
+
+```bash
+mlship benchmark model.pkl
+```
+
+This runs 100 requests and shows:
+- Cold start latency
+- Average latency
+- Percentiles (P50, P95, P99)
+- Throughput (requests/sec)
+
+### Example Output
+
+```
+==================================================
+Model: sklearn_model.pkl
+Framework: sklearn
+Warmup requests: 5
+Benchmark requests: 100
+==================================================
+
+Measuring cold start latency...
+Cold start: 0.234s
+
+Warming up...
+Warmup: 5/5
+
+Running 100 requests...
+Progress: 100/100
+
+==================================================
+BENCHMARK RESULTS
+==================================================
+
+Cold Start:     234.00ms
+
+Performance Metrics:
+  Average:       45.23ms
+  Min:           32.10ms
+  P50 (Median):  44.50ms
+  P95:           67.80ms
+  P99:           89.20ms
+  Max:           102.30ms
+
+Throughput:     ~22.1 requests/sec
+==================================================
+```
+
+### Advanced Options
+
+**More requests:**
+```bash
+mlship benchmark model.pkl --requests 1000
+```
+
+**JSON output (for automation):**
+```bash
+mlship benchmark model.pkl --output json > results.json
+```
+
+**Custom payload:**
+```bash
+mlship benchmark model.pkl --payload '{"features": [1.0, 2.0, 3.0, 4.0]}'
+```
+
+**Benchmark HuggingFace Hub model:**
+```bash
+mlship benchmark distilbert-base-uncased-finetuned-sst-2-english --source huggingface --requests 50
+```
+
+**Custom port:**
+```bash
+mlship benchmark model.pkl --port 5000
+```
+
+### When to Benchmark
+
+- Before deploying to production
+- After model changes
+- To compare different model formats
+- To validate performance requirements
+
+---
+
 ## Framework Support
 
 | Framework | Install | Serve Command |

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -488,20 +488,50 @@ mlship benchmark model.pkl --payload '{"features": [1.0, 2.0, 3.0, 4.0]}'
 
 **Benchmark HuggingFace Hub model:**
 ```bash
-mlship benchmark distilbert-base-uncased-finetuned-sst-2-english --source huggingface --requests 50
+mlship benchmark distilbert-base-uncased-finetuned-sst-2-english --source huggingface --requests 20 --warmup 3
 ```
+
+The benchmark command handles everything automatically:
+- ✅ Detects HuggingFace model and downloads it (first time only, then cached)
+- ✅ Starts mlship server in background
+- ✅ Runs warmup requests to stabilize performance
+- ✅ Measures cold start latency (first prediction)
+- ✅ Runs benchmark requests and collects metrics
+- ✅ Shows detailed performance results
+- ✅ Stops server and cleans up
 
 **Custom port:**
 ```bash
 mlship benchmark model.pkl --port 5000
 ```
 
+### Understanding Benchmark Results
+
+**Cold Start Time:**
+- First run: ~300-400ms (model loads from disk)
+- Subsequent runs: ~30-50ms (model cached)
+- This is normal - production keeps models in memory
+
+**Latency Variance:**
+- 15-30% variance between runs is normal
+- Caused by: CPU throttling, background processes, OS scheduler
+- Run with `--requests 1000` for more stable averages
+- **P95/P99 matter** - these show worst-case latency
+
+**Example comparison:**
+```bash
+# Compare sklearn vs HuggingFace performance
+mlship benchmark sklearn_model.pkl --requests 100
+mlship benchmark distilbert-base-uncased-finetuned-sst-2-english --source huggingface --requests 100
+```
+
 ### When to Benchmark
 
 - Before deploying to production
 - After model changes
-- To compare different model formats
-- To validate performance requirements
+- To compare different model formats (sklearn vs PyTorch vs TensorFlow)
+- To validate performance requirements (e.g., "P95 must be < 50ms")
+- To detect performance regressions
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Deploy your machine learning models locally in seconds - no Docker, no YAML, no 
 - ✅ **One-command deployment** - No configuration needed
 - ✅ **Multi-framework** - sklearn, PyTorch, TensorFlow, HuggingFace (local + Hub)
 - ✅ **HuggingFace Hub** - Serve models directly from Hub without downloading
+- ✅ **Built-in benchmarking** - Measure latency and throughput with `mlship benchmark`
 - ✅ **Auto-generated API** - REST API with interactive docs
 - ✅ **Works offline** - Zero internet dependency after installation
 - ✅ **Fast** - Deploy in seconds, predictions in milliseconds
@@ -109,9 +110,17 @@ mlship serve model.pkl --name "fraud-detector"
 
 # Custom preprocessing/postprocessing
 mlship serve model.pkl --pipeline my_module.MyPipeline
+
+# Benchmark performance
+mlship benchmark model.pkl --requests 1000
+
+# Benchmark with JSON output
+mlship benchmark model.pkl --output json > results.json
 ```
 
 See [CONTRIBUTING.md](https://github.com/sudhanvalabs/mlship/blob/main/CONTRIBUTING.md) for custom pipeline documentation.
+
+See [QUICKSTART.md](https://github.com/sudhanvalabs/mlship/blob/main/QUICKSTART.md#benchmarking-your-model) for detailed benchmarking guide.
 
 ---
 
@@ -223,6 +232,7 @@ mlship is the **only zero-code tool** that supports sklearn, PyTorch, TensorFlow
 - ✅ **Multi-framework support** - sklearn, PyTorch, TensorFlow, HuggingFace
 - ✅ **HuggingFace Hub integration** - Serve models directly from Hub with `--source huggingface`
 - ✅ **PyTorch TorchScript support** - Full support for custom PyTorch models via TorchScript
+- ✅ **Built-in benchmarking** - Measure latency (p50/p95/p99) and throughput with `mlship benchmark`
 - ✅ **Zero-code deployment** - One command to serve any model
 - ✅ **Auto-generated REST API** - With interactive Swagger docs
 - ✅ **Custom pipelines** - Preprocessing/postprocessing support

--- a/README.md
+++ b/README.md
@@ -114,9 +114,29 @@ mlship serve model.pkl --pipeline my_module.MyPipeline
 # Benchmark performance
 mlship benchmark model.pkl --requests 1000
 
-# Benchmark with JSON output
+# Benchmark with custom warmup and port
+mlship benchmark model.pkl --requests 500 --warmup 10 --port 9000
+
+# Benchmark with custom payload
+mlship benchmark model.pkl --payload '{"features": [5.1, 3.5, 1.4, 0.2]}'
+
+# Benchmark HuggingFace model
+mlship benchmark distilbert-base-uncased-finetuned-sst-2-english --source huggingface --requests 50
+
+# Benchmark with JSON output (for CI/CD)
 mlship benchmark model.pkl --output json > results.json
 ```
+
+**Benchmark options:**
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--requests N` | 100 | Number of benchmark requests |
+| `--warmup N` | 5 | Number of warmup requests |
+| `--port PORT` | 8000 | Server port |
+| `--payload JSON` | auto | Custom test payload as JSON string |
+| `--source` | local | Model source (`local` or `huggingface`) |
+| `--output` | text | Output format (`text` or `json`) |
 
 See [CONTRIBUTING.md](https://github.com/sudhanvalabs/mlship/blob/main/CONTRIBUTING.md) for custom pipeline documentation.
 

--- a/WHY_MLSHIP.md
+++ b/WHY_MLSHIP.md
@@ -39,7 +39,7 @@ Same command pattern. Same API format. Same workflow.
 
 | Tool | Frameworks Supported | Code Required | Best For |
 |------|---------------------|---------------|----------|
-| **mlship** | sklearn, PyTorch, TF, HF | **Zero** | Multi-framework teams, rapid prototyping, learning |
+| **mlship** | sklearn, PyTorch, TF, HF | **Zero** | Multi-framework teams, rapid prototyping, learning, benchmarking |
 | transformers-serve | HuggingFace only | Zero | HF models exclusively |
 | vLLM | LLMs only | Zero | Production LLM serving (high performance) |
 | Ollama | LLMs only | Zero | Local LLM chat interfaces |
@@ -103,7 +103,22 @@ curl -X POST http://localhost:8000/predict \
 
 Your application code doesn't need to know which framework you're using.
 
-### 5. Educational Sweet Spot
+### 5. Built-in Performance Benchmarking
+
+Measure model serving performance without external tools:
+
+```bash
+# Benchmark any model with one command
+mlship benchmark model.pkl --requests 100
+
+# Compare frameworks with JSON output
+mlship benchmark model.pt --output json > pytorch_results.json
+mlship benchmark model.pkl --output json > sklearn_results.json
+```
+
+Get cold start latency, avg/min/p50/p95/p99/max latency, and throughput (RPS) — useful for framework comparison, performance regression testing, and CI/CD integration. No other zero-code serving tool includes built-in benchmarking.
+
+### 6. Educational Sweet Spot
 
 Perfect for courses, tutorials, and learning:
 

--- a/mlship/__init__.py
+++ b/mlship/__init__.py
@@ -1,6 +1,6 @@
 """mlship - Turn ML models into APIs with one command."""
 
-__version__ = "0.1.5"
+__version__ = "0.2.0"
 __author__ = "Sudhanva Labs"
 __license__ = "MIT"
 

--- a/mlship/benchmark.py
+++ b/mlship/benchmark.py
@@ -28,9 +28,21 @@ def start_server_background(
         ready_event: Event to signal when server is ready
     """
     import uvicorn
+    from mlship.loaders import get_loader
+
+    # Detect framework and load model
+    framework = detect_framework(model_path, source=source)
+    loader = get_loader(framework)
+    model = loader.load(model_path)
+
+    # Get model name
+    if isinstance(model_path, Path):
+        model_name = model_path.stem
+    else:
+        model_name = str(model_path).split("/")[-1]
 
     # Create the app
-    app = create_app(model_path, source=source)
+    app = create_app(model, loader, model_name, pipeline=None)
 
     # Signal that we're ready
     ready_event.set()

--- a/mlship/benchmark.py
+++ b/mlship/benchmark.py
@@ -1,0 +1,258 @@
+"""Benchmarking utilities for mlship."""
+
+import multiprocessing
+import statistics
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+
+import requests
+
+from mlship.loaders.detector import detect_framework
+from mlship.server import create_app
+
+
+def start_server_background(
+    model_path: Union[Path, str],
+    port: int,
+    source: str,
+    ready_event: multiprocessing.Event,
+) -> None:
+    """Start mlship server in background process.
+
+    Args:
+        model_path: Path to model file or HuggingFace model ID
+        port: Port to run server on
+        source: Model source ('local' or 'huggingface')
+        ready_event: Event to signal when server is ready
+    """
+    import uvicorn
+
+    # Create the app
+    app = create_app(model_path, source=source)
+
+    # Signal that we're ready
+    ready_event.set()
+
+    # Run server
+    config = uvicorn.Config(
+        app,
+        host="127.0.0.1",
+        port=port,
+        log_level="error",  # Suppress logs during benchmarking
+        access_log=False,
+    )
+    server = uvicorn.Server(config)
+    server.run()
+
+
+def wait_for_server(url: str, timeout: int = 30) -> bool:
+    """Wait for server to be ready.
+
+    Args:
+        url: Base URL of the server
+        timeout: Maximum time to wait in seconds
+
+    Returns:
+        True if server is ready, False if timeout
+    """
+    health_url = f"{url}/health"
+    start = time.time()
+
+    while time.time() - start < timeout:
+        try:
+            response = requests.get(health_url, timeout=1)
+            if response.status_code == 200:
+                return True
+        except requests.exceptions.RequestException:
+            pass
+        time.sleep(0.1)
+
+    return False
+
+
+def generate_test_payload(framework: str) -> Dict[str, Any]:
+    """Generate appropriate test payload for framework.
+
+    Args:
+        framework: Framework name (sklearn, pytorch, tensorflow, huggingface)
+
+    Returns:
+        Test payload dictionary
+    """
+    if framework == "huggingface":
+        return {"features": "This is a test sentence for benchmarking."}
+    else:
+        # Numeric features for sklearn, pytorch, tensorflow
+        return {"features": [1.0, 2.0, 3.0, 4.0]}
+
+
+def run_benchmark(
+    model_path: Union[Path, str],
+    port: int = 8000,
+    num_requests: int = 100,
+    warmup: int = 5,
+    source: str = "local",
+    payload: Optional[Dict[str, Any]] = None,
+    output_format: str = "text",
+) -> Dict[str, Any]:
+    """Run benchmark on a model.
+
+    Args:
+        model_path: Path to model file or HuggingFace model ID
+        port: Port to run server on
+        num_requests: Number of benchmark requests
+        warmup: Number of warmup requests
+        source: Model source ('local' or 'huggingface')
+        payload: Custom test payload (optional)
+        output_format: Output format ('text' or 'json')
+
+    Returns:
+        Dictionary with benchmark results
+    """
+    base_url = f"http://127.0.0.1:{port}"
+    predict_url = f"{base_url}/predict"
+
+    # Detect framework to generate appropriate payload
+    framework = detect_framework(model_path, source=source)
+
+    # Use custom payload or generate default
+    test_payload = payload if payload else generate_test_payload(framework)
+
+    # Start server in background process
+    if output_format == "text":
+        print(f"Starting mlship server on port {port}...")
+
+    ready_event = multiprocessing.Event()
+    server_process = multiprocessing.Process(
+        target=start_server_background,
+        args=(model_path, port, source, ready_event),
+        daemon=True,
+    )
+    server_process.start()
+
+    # Wait for ready event and server to be accessible
+    ready_event.wait(timeout=10)
+    time.sleep(1)  # Give server a moment to fully start
+
+    if not wait_for_server(base_url, timeout=30):
+        server_process.terminate()
+        server_process.join(timeout=5)
+        raise RuntimeError("Server failed to start within timeout")
+
+    try:
+        if output_format == "text":
+            print(f"Server started. Running benchmark...\n")
+            print("=" * 50)
+            print(f"Model: {model_path}")
+            print(f"Framework: {framework}")
+            print(f"Warmup requests: {warmup}")
+            print(f"Benchmark requests: {num_requests}")
+            print("=" * 50)
+
+        # Measure cold start
+        if output_format == "text":
+            print("\nMeasuring cold start latency...")
+
+        cold_start_time = time.time()
+        try:
+            response = requests.post(predict_url, json=test_payload, timeout=30)
+            cold_start_duration = time.time() - cold_start_time
+
+            if response.status_code != 200:
+                raise RuntimeError(
+                    f"Server returned status {response.status_code}: {response.text}"
+                )
+
+            if output_format == "text":
+                print(f"Cold start: {cold_start_duration:.3f}s")
+
+        except requests.exceptions.RequestException as e:
+            raise RuntimeError(f"Failed to connect to server: {e}")
+
+        # Warmup
+        if output_format == "text":
+            print(f"\nWarming up...")
+
+        for i in range(warmup):
+            requests.post(predict_url, json=test_payload, timeout=10)
+            if output_format == "text":
+                sys.stdout.write(f"\rWarmup: {i+1}/{warmup}")
+                sys.stdout.flush()
+
+        if output_format == "text":
+            print()
+
+        # Run benchmark
+        if output_format == "text":
+            print(f"\nRunning {num_requests} requests...")
+
+        latencies: List[float] = []
+        start_time = time.time()
+
+        for i in range(num_requests):
+            req_start = time.time()
+            response = requests.post(predict_url, json=test_payload, timeout=10)
+            req_duration = (time.time() - req_start) * 1000  # Convert to ms
+            latencies.append(req_duration)
+
+            if output_format == "text" and (i + 1) % 10 == 0:
+                sys.stdout.write(f"\rProgress: {i+1}/{num_requests}")
+                sys.stdout.flush()
+
+        total_time = time.time() - start_time
+
+        if output_format == "text":
+            print()
+
+        # Calculate statistics
+        latencies.sort()
+        p50 = statistics.median(latencies)
+        p95 = latencies[int(len(latencies) * 0.95)]
+        p99 = latencies[int(len(latencies) * 0.99)]
+        avg = statistics.mean(latencies)
+        min_latency = min(latencies)
+        max_latency = max(latencies)
+        throughput = num_requests / total_time
+
+        results = {
+            "model": str(model_path),
+            "framework": framework,
+            "cold_start_ms": cold_start_duration * 1000,
+            "warmup_requests": warmup,
+            "benchmark_requests": num_requests,
+            "avg_ms": avg,
+            "min_ms": min_latency,
+            "p50_ms": p50,
+            "p95_ms": p95,
+            "p99_ms": p99,
+            "max_ms": max_latency,
+            "throughput_rps": throughput,
+        }
+
+        if output_format == "text":
+            print("\n" + "=" * 50)
+            print("BENCHMARK RESULTS")
+            print("=" * 50)
+            print(f"\nCold Start:     {cold_start_duration*1000:.2f}ms")
+            print(f"\nPerformance Metrics:")
+            print(f"  Average:       {avg:.2f}ms")
+            print(f"  Min:           {min_latency:.2f}ms")
+            print(f"  P50 (Median):  {p50:.2f}ms")
+            print(f"  P95:           {p95:.2f}ms")
+            print(f"  P99:           {p99:.2f}ms")
+            print(f"  Max:           {max_latency:.2f}ms")
+            print(f"\nThroughput:     ~{throughput:.1f} requests/sec")
+            print("=" * 50)
+
+        return results
+
+    finally:
+        # Stop server
+        if output_format == "text":
+            print("\nStopping server...")
+        server_process.terminate()
+        server_process.join(timeout=5)
+        if server_process.is_alive():
+            server_process.kill()

--- a/mlship/benchmark.py
+++ b/mlship/benchmark.py
@@ -155,7 +155,7 @@ def run_benchmark(
 
     try:
         if output_format == "text":
-            print(f"Server started. Running benchmark...\n")
+            print("Server started. Running benchmark...\n")
             print("=" * 50)
             print(f"Model: {model_path}")
             print(f"Framework: {framework}")
@@ -185,7 +185,7 @@ def run_benchmark(
 
         # Warmup
         if output_format == "text":
-            print(f"\nWarming up...")
+            print("\nWarming up...")
 
         for i in range(warmup):
             requests.post(predict_url, json=test_payload, timeout=30)
@@ -248,7 +248,7 @@ def run_benchmark(
             print("BENCHMARK RESULTS")
             print("=" * 50)
             print(f"\nCold Start:     {cold_start_duration*1000:.2f}ms")
-            print(f"\nPerformance Metrics:")
+            print("\nPerformance Metrics:")
             print(f"  Average:       {avg:.2f}ms")
             print(f"  Min:           {min_latency:.2f}ms")
             print(f"  P50 (Median):  {p50:.2f}ms")

--- a/mlship/benchmark.py
+++ b/mlship/benchmark.py
@@ -188,7 +188,7 @@ def run_benchmark(
             print(f"\nWarming up...")
 
         for i in range(warmup):
-            requests.post(predict_url, json=test_payload, timeout=10)
+            requests.post(predict_url, json=test_payload, timeout=30)
             if output_format == "text":
                 sys.stdout.write(f"\rWarmup: {i+1}/{warmup}")
                 sys.stdout.flush()
@@ -205,7 +205,7 @@ def run_benchmark(
 
         for i in range(num_requests):
             req_start = time.time()
-            response = requests.post(predict_url, json=test_payload, timeout=10)
+            response = requests.post(predict_url, json=test_payload, timeout=30)
             req_duration = (time.time() - req_start) * 1000  # Convert to ms
             latencies.append(req_duration)
 

--- a/mlship/cli.py
+++ b/mlship/cli.py
@@ -1,5 +1,6 @@
 """Command-line interface for mlship."""
 
+import json
 import sys
 from pathlib import Path
 
@@ -7,6 +8,7 @@ import click
 import uvicorn
 
 from mlship import __version__
+from mlship.benchmark import run_benchmark
 from mlship.errors import UnsupportedModelError, ModelLoadError
 from mlship.loaders import detect_framework, get_loader
 from mlship.server import create_app
@@ -20,13 +22,18 @@ def cli(ctx, version):
     """
     mlship - Turn ML models into APIs with one command.
 
+    Commands:
+
+      serve      Start API server for your model
+      benchmark  Measure model serving performance
+
     Examples:
 
       mlship serve model.pkl
 
       mlship serve model.pt --port 5000
 
-      mlship serve model.h5 --name "sentiment-analyzer"
+      mlship benchmark model.pkl --requests 1000
     """
     if version:
         click.echo(f"mlship version {__version__}")
@@ -262,6 +269,147 @@ def serve(
     except KeyboardInterrupt:
         click.echo()
         click.secho("\n👋 Shutting down...", fg="yellow")
+        click.echo()
+        sys.exit(0)
+
+    except Exception as e:
+        click.echo()
+        click.secho("❌ Unexpected Error", fg="red", bold=True, err=True)
+        click.echo()
+        click.echo(f"{type(e).__name__}: {e}", err=True)
+        click.echo()
+        click.secho(
+            "Please report this issue: https://github.com/sudhanvalabs/mlship/issues",
+            fg="yellow",
+            err=True,
+        )
+        click.echo()
+        sys.exit(1)
+
+
+@cli.command()
+@click.argument("model_file", type=str)
+@click.option("--port", default=8000, type=int, help="Port to run server on (default: 8000)")
+@click.option(
+    "--requests", default=100, type=int, help="Number of benchmark requests (default: 100)"
+)
+@click.option("--warmup", default=5, type=int, help="Number of warmup requests (default: 5)")
+@click.option(
+    "--source",
+    type=click.Choice(["local", "huggingface"], case_sensitive=False),
+    default="local",
+    help="Model source: 'local' for file paths (default) or 'huggingface' for Hub models",
+)
+@click.option(
+    "--output",
+    type=click.Choice(["text", "json"], case_sensitive=False),
+    default="text",
+    help="Output format: 'text' (default) or 'json'",
+)
+@click.option("--payload", default=None, type=str, help="Custom test payload as JSON string")
+def benchmark(
+    model_file: str, port: int, requests: int, warmup: int, source: str, output: str, payload: str
+):
+    """
+    Benchmark model serving performance.
+
+    Measures latency (avg, p50, p95, p99) and throughput for serving a model.
+
+    MODEL_FILE can be:
+      - Path to a trained model file (.pkl, .pt, .h5, etc.) [--source local]
+      - HuggingFace Hub model ID (e.g., 'bert-base-uncased') [--source huggingface]
+
+    Examples:
+
+      mlship benchmark model.pkl
+
+      mlship benchmark model.pkl --requests 1000
+
+      mlship benchmark gpt2 --source huggingface --requests 50
+
+      mlship benchmark model.pkl --output json > results.json
+
+      mlship benchmark model.pkl --payload '{"features": [1, 2, 3, 4]}'
+    """
+    # Handle local vs Hub models
+    if source == "local":
+        # Validate that local path exists
+        model_path_obj = Path(model_file)
+        if not model_path_obj.exists():
+            click.echo()
+            click.secho("❌ Error: File Not Found", fg="red", bold=True, err=True)
+            click.echo()
+            click.echo(f"The model file does not exist: {model_file}", err=True)
+            click.echo()
+            click.echo("If you're trying to load from HuggingFace Hub, use:", err=True)
+            click.echo(f"  mlship benchmark {model_file} --source huggingface", err=True)
+            click.echo()
+            sys.exit(1)
+
+        model_path = model_path_obj
+    else:  # source == "huggingface"
+        # For Hub models, keep as string
+        model_path = model_file
+
+    # Parse custom payload if provided
+    custom_payload = None
+    if payload:
+        try:
+            custom_payload = json.loads(payload)
+        except json.JSONDecodeError as e:
+            click.echo()
+            click.secho("❌ Error: Invalid JSON Payload", fg="red", bold=True, err=True)
+            click.echo()
+            click.echo(f"Failed to parse payload: {e}", err=True)
+            click.echo()
+            click.echo("Payload must be valid JSON, e.g.:", err=True)
+            click.echo('  --payload \'{"features": [1.0, 2.0, 3.0, 4.0]}\'', err=True)
+            click.echo()
+            sys.exit(1)
+
+    try:
+        # Run benchmark
+        results = run_benchmark(
+            model_path=model_path,
+            port=port,
+            num_requests=requests,
+            warmup=warmup,
+            source=source,
+            payload=custom_payload,
+            output_format=output,
+        )
+
+        # Output JSON if requested
+        if output == "json":
+            click.echo(json.dumps(results, indent=2))
+
+    except UnsupportedModelError as e:
+        click.echo()
+        click.secho("❌ Error: Unsupported Model Format", fg="red", bold=True, err=True)
+        click.echo()
+        click.echo(str(e), err=True)
+        click.echo()
+        sys.exit(1)
+
+    except ModelLoadError as e:
+        click.echo()
+        click.secho("❌ Error: Failed to Load Model", fg="red", bold=True, err=True)
+        click.echo()
+        click.echo(str(e), err=True)
+        click.echo()
+        sys.exit(1)
+
+    except RuntimeError as e:
+        click.echo()
+        click.secho("❌ Benchmark Error", fg="red", bold=True, err=True)
+        click.echo()
+        click.echo(str(e), err=True)
+        click.echo()
+        sys.exit(1)
+
+    except KeyboardInterrupt:
+        click.echo()
+        click.secho("\n👋 Benchmark cancelled", fg="yellow")
         click.echo()
         sys.exit(0)
 

--- a/mlship/cli.py
+++ b/mlship/cli.py
@@ -363,7 +363,7 @@ def benchmark(
             click.echo(f"Failed to parse payload: {e}", err=True)
             click.echo()
             click.echo("Payload must be valid JSON, e.g.:", err=True)
-            click.echo('  --payload \'{"features": [1.0, 2.0, 3.0, 4.0]}\'', err=True)
+            click.echo("  --payload '{\"features\": [1.0, 2.0, 3.0, 4.0]}'", err=True)
             click.echo()
             sys.exit(1)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "uvicorn[standard]>=0.24",
     "pydantic>=2.0",
     "python-multipart>=0.0.6",
+    "requests>=2.31",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mlship"
-version = "0.1.5"
+version = "0.2.0"
 description = "Turn ML models into APIs with one command"
 authors = [{name = "Sudhanva Labs", email = "contact@sudhanvalabs.com"}]
 license = {text = "MIT"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,9 @@ python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
 addopts = "-v --cov=mlship --cov-report=term-missing"
+markers = [
+    "slow: marks tests as slow (e.g., HuggingFace Hub downloads)",
+]
 filterwarnings = [
     "ignore::FutureWarning:keras.*",
     "ignore::DeprecationWarning:keras.*",

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,59 @@
+## Test Suite Structure
+
+This directory contains comprehensive tests for mlship across all supported frameworks.
+
+### Test Files
+
+- **`test_loaders.py`** - Unit tests for model loaders (sklearn, PyTorch, TensorFlow, HuggingFace)
+- **`test_cli.py`** - Unit tests for CLI commands and argument parsing
+- **`test_benchmark.py`** - Unit tests for benchmark module functions
+- **`test_integration.py`** - Integration tests for FastAPI endpoints with all model types
+- **`test_cli_integration.py`** - End-to-end tests for CLI commands (`mlship serve`, `mlship benchmark`)
+- **`fixtures.py`** - Shared test fixtures for creating test models
+
+### Running Tests
+
+**Run all tests:**
+```bash
+pytest tests/ -v
+```
+
+**Run specific test file:**
+```bash
+pytest tests/test_cli_integration.py -v
+```
+
+**Run specific test:**
+```bash
+pytest tests/test_cli_integration.py::TestServeCommandCLI::test_serve_sklearn_cli -v
+```
+
+**Skip slow tests (HuggingFace Hub downloads):**
+```bash
+pytest -m "not slow"
+```
+
+**Run only slow tests:**
+```bash
+pytest -m "slow"
+```
+
+### Test Coverage
+
+The test suite provides coverage across:
+
+| Area | Coverage |
+|------|----------|
+| **Model Types** | sklearn, PyTorch, TensorFlow, HuggingFace |
+| **Commands** | `serve`, `benchmark` |
+| **Endpoints** | `/predict`, `/health`, `/info`, `/docs` |
+| **Features** | Custom payloads, output formats, error handling |
+
+### CI/CD Integration
+
+These tests run automatically on:
+- Every pull request
+- Every push to main branch
+- Before release
+
+Tests ensure backward compatibility and prevent regressions across all supported frameworks.

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -67,12 +67,14 @@ def tensorflow_model() -> Path:
     X = np.random.rand(100, 4).astype(np.float32)
     y = np.random.randint(0, 2, 100)
 
-    model = tf.keras.Sequential([
-        tf.keras.layers.Dense(8, activation='relu', input_shape=(4,)),
-        tf.keras.layers.Dense(1, activation='sigmoid')
-    ])
+    model = tf.keras.Sequential(
+        [
+            tf.keras.layers.Dense(8, activation="relu", input_shape=(4,)),
+            tf.keras.layers.Dense(1, activation="sigmoid"),
+        ]
+    )
 
-    model.compile(optimizer='adam', loss='binary_crossentropy')
+    model.compile(optimizer="adam", loss="binary_crossentropy")
     model.fit(X, y, epochs=5, verbose=0)
 
     temp_file = tempfile.NamedTemporaryFile(suffix=".keras", delete=False)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,0 +1,104 @@
+"""Test fixtures for creating models across all supported frameworks."""
+
+import tempfile
+from pathlib import Path
+from typing import Dict
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def sklearn_model() -> Path:
+    """Create a sklearn model for testing."""
+    from sklearn.ensemble import RandomForestClassifier
+    from sklearn.datasets import make_classification
+    import joblib
+
+    X, y = make_classification(n_samples=100, n_features=4, random_state=42)
+    model = RandomForestClassifier(n_estimators=5, random_state=42)
+    model.fit(X, y)
+
+    temp_file = tempfile.NamedTemporaryFile(suffix=".pkl", delete=False)
+    joblib.dump(model, temp_file.name)
+    temp_file.close()
+
+    yield Path(temp_file.name)
+
+    # Cleanup
+    Path(temp_file.name).unlink(missing_ok=True)
+
+
+@pytest.fixture(scope="session")
+def pytorch_model() -> Path:
+    """Create a PyTorch TorchScript model for testing."""
+    torch = pytest.importorskip("torch")
+    import torch.nn as nn
+
+    class SimpleModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.fc = nn.Linear(4, 2)
+
+        def forward(self, x):
+            return self.fc(x)
+
+    model = SimpleModel()
+    model.eval()
+
+    # Save as TorchScript
+    scripted_model = torch.jit.script(model)
+
+    temp_file = tempfile.NamedTemporaryFile(suffix=".pt", delete=False)
+    torch.jit.save(scripted_model, temp_file.name)
+    temp_file.close()
+
+    yield Path(temp_file.name)
+
+    # Cleanup
+    Path(temp_file.name).unlink(missing_ok=True)
+
+
+@pytest.fixture(scope="session")
+def tensorflow_model() -> Path:
+    """Create a TensorFlow/Keras model for testing."""
+    tf = pytest.importorskip("tensorflow")
+    import numpy as np
+
+    X = np.random.rand(100, 4).astype(np.float32)
+    y = np.random.randint(0, 2, 100)
+
+    model = tf.keras.Sequential([
+        tf.keras.layers.Dense(8, activation='relu', input_shape=(4,)),
+        tf.keras.layers.Dense(1, activation='sigmoid')
+    ])
+
+    model.compile(optimizer='adam', loss='binary_crossentropy')
+    model.fit(X, y, epochs=5, verbose=0)
+
+    temp_file = tempfile.NamedTemporaryFile(suffix=".keras", delete=False)
+    model.save(temp_file.name)
+    temp_file.close()
+
+    yield Path(temp_file.name)
+
+    # Cleanup
+    Path(temp_file.name).unlink(missing_ok=True)
+
+
+@pytest.fixture(scope="session")
+def huggingface_model_id() -> str:
+    """Return a small HuggingFace Hub model ID for testing."""
+    pytest.importorskip("transformers")
+    # Use a small, fast model for testing
+    return "distilbert-base-uncased-finetuned-sst-2-english"
+
+
+@pytest.fixture(scope="session")
+def test_payloads() -> Dict[str, dict]:
+    """Return appropriate test payloads for each framework."""
+    return {
+        "sklearn": {"features": [1.0, 2.0, 3.0, 4.0]},
+        "pytorch": {"features": [1.0, 2.0, 3.0, 4.0]},
+        "tensorflow": {"features": [0.5, 1.2, -0.3, 0.8]},
+        "huggingface": {"features": "This is a test sentence."},
+    }

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,0 +1,208 @@
+"""Tests for benchmarking functionality."""
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from mlship.cli import cli
+
+
+class TestBenchmarkCommand:
+    """Test benchmark CLI command."""
+
+    def test_benchmark_sklearn_model(self, tmp_path):
+        """Test benchmarking sklearn model."""
+        # Create a simple sklearn model
+        import joblib
+        from sklearn.ensemble import RandomForestClassifier
+        from sklearn.datasets import make_classification
+
+        X, y = make_classification(n_samples=100, n_features=4, random_state=42)
+        model = RandomForestClassifier(n_estimators=10, random_state=42)
+        model.fit(X, y)
+
+        model_path = tmp_path / "test_model.pkl"
+        joblib.dump(model, model_path)
+
+        # Run benchmark
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "benchmark",
+                str(model_path),
+                "--requests",
+                "10",
+                "--warmup",
+                "2",
+                "--port",
+                "8765",
+            ],
+        )
+
+        # Check that it succeeded
+        assert result.exit_code == 0, f"Command failed with output: {result.output}"
+
+        # Check output contains expected text
+        assert "BENCHMARK RESULTS" in result.output
+        assert "Cold Start:" in result.output
+        assert "Average:" in result.output
+        assert "P50 (Median):" in result.output
+        assert "P95:" in result.output
+        assert "P99:" in result.output
+        assert "Throughput:" in result.output
+
+    def test_benchmark_json_output(self, tmp_path):
+        """Test benchmark with JSON output."""
+        # Create a simple sklearn model
+        import joblib
+        from sklearn.ensemble import RandomForestClassifier
+        from sklearn.datasets import make_classification
+
+        X, y = make_classification(n_samples=100, n_features=4, random_state=42)
+        model = RandomForestClassifier(n_estimators=10, random_state=42)
+        model.fit(X, y)
+
+        model_path = tmp_path / "test_model.pkl"
+        joblib.dump(model, model_path)
+
+        # Run benchmark with JSON output
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "benchmark",
+                str(model_path),
+                "--requests",
+                "10",
+                "--warmup",
+                "2",
+                "--port",
+                "8766",
+                "--output",
+                "json",
+            ],
+        )
+
+        # Check that it succeeded
+        assert result.exit_code == 0, f"Command failed with output: {result.output}"
+
+        # Parse JSON output
+        output_data = json.loads(result.output)
+
+        # Verify required fields
+        assert "model" in output_data
+        assert "framework" in output_data
+        assert output_data["framework"] == "sklearn"
+        assert "cold_start_ms" in output_data
+        assert "avg_ms" in output_data
+        assert "min_ms" in output_data
+        assert "p50_ms" in output_data
+        assert "p95_ms" in output_data
+        assert "p99_ms" in output_data
+        assert "max_ms" in output_data
+        assert "throughput_rps" in output_data
+        assert "warmup_requests" in output_data
+        assert output_data["warmup_requests"] == 2
+        assert "benchmark_requests" in output_data
+        assert output_data["benchmark_requests"] == 10
+
+        # Verify values are reasonable
+        assert output_data["cold_start_ms"] > 0
+        assert output_data["avg_ms"] > 0
+        assert output_data["throughput_rps"] > 0
+
+    def test_benchmark_custom_payload(self, tmp_path):
+        """Test benchmark with custom payload."""
+        # Create a simple sklearn model
+        import joblib
+        from sklearn.ensemble import RandomForestClassifier
+        from sklearn.datasets import make_classification
+
+        X, y = make_classification(n_samples=100, n_features=4, random_state=42)
+        model = RandomForestClassifier(n_estimators=10, random_state=42)
+        model.fit(X, y)
+
+        model_path = tmp_path / "test_model.pkl"
+        joblib.dump(model, model_path)
+
+        # Run benchmark with custom payload
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "benchmark",
+                str(model_path),
+                "--requests",
+                "5",
+                "--warmup",
+                "1",
+                "--port",
+                "8767",
+                "--payload",
+                '{"features": [1.0, 2.0, 3.0, 4.0]}',
+            ],
+        )
+
+        # Check that it succeeded
+        assert result.exit_code == 0, f"Command failed with output: {result.output}"
+        assert "BENCHMARK RESULTS" in result.output
+
+    def test_benchmark_invalid_payload(self, tmp_path):
+        """Test benchmark with invalid JSON payload."""
+        # Create a simple sklearn model
+        import joblib
+        from sklearn.ensemble import RandomForestClassifier
+        from sklearn.datasets import make_classification
+
+        X, y = make_classification(n_samples=100, n_features=4, random_state=42)
+        model = RandomForestClassifier(n_estimators=10, random_state=42)
+        model.fit(X, y)
+
+        model_path = tmp_path / "test_model.pkl"
+        joblib.dump(model, model_path)
+
+        # Run benchmark with invalid payload
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "benchmark",
+                str(model_path),
+                "--payload",
+                "not valid json",
+            ],
+        )
+
+        # Should fail with error
+        assert result.exit_code != 0
+        assert "Invalid JSON Payload" in result.output
+
+    def test_benchmark_nonexistent_file(self):
+        """Test benchmark with non-existent file."""
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["benchmark", "nonexistent_model.pkl"],
+        )
+
+        # Should fail with error
+        assert result.exit_code != 0
+        assert "File Not Found" in result.output
+
+    def test_benchmark_help(self):
+        """Test benchmark help message."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["benchmark", "--help"])
+
+        assert result.exit_code == 0
+        assert "Benchmark model serving performance" in result.output
+        assert "--requests" in result.output
+        assert "--warmup" in result.output
+        assert "--port" in result.output
+        assert "--source" in result.output
+        assert "--output" in result.output
+        assert "--payload" in result.output

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,10 +1,7 @@
 """Tests for benchmarking functionality."""
 
 import json
-import tempfile
-from pathlib import Path
 
-import pytest
 from click.testing import CliRunner
 
 from mlship.cli import cli

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -131,6 +131,11 @@ class TestServeCommandCLI:
             time.sleep(0.5)
         return False
 
+    @pytest.mark.skipif(
+        IS_WINDOWS,
+        reason="Subprocess-based serve tests unreliable on Windows CI; "
+        "serve is covered by test-frameworks CI job on Windows",
+    )
     def test_serve_sklearn_cli(self, sklearn_model_file):
         """Test mlship serve with sklearn model."""
         port = 8101
@@ -151,6 +156,11 @@ class TestServeCommandCLI:
         finally:
             self.stop_serve_process(proc)
 
+    @pytest.mark.skipif(
+        IS_WINDOWS,
+        reason="Subprocess-based serve tests unreliable on Windows CI; "
+        "serve is covered by test-frameworks CI job on Windows",
+    )
     def test_serve_pytorch_cli(self, pytorch_model_file):
         """Test mlship serve with PyTorch model."""
         port = 8102
@@ -171,6 +181,11 @@ class TestServeCommandCLI:
         finally:
             self.stop_serve_process(proc)
 
+    @pytest.mark.skipif(
+        IS_WINDOWS,
+        reason="Subprocess-based serve tests unreliable on Windows CI; "
+        "serve is covered by test-frameworks CI job on Windows",
+    )
     def test_serve_tensorflow_cli(self, tensorflow_model_file):
         """Test mlship serve with TensorFlow model."""
         port = 8103
@@ -192,6 +207,11 @@ class TestServeCommandCLI:
             self.stop_serve_process(proc)
 
     @pytest.mark.slow
+    @pytest.mark.skipif(
+        IS_WINDOWS,
+        reason="Subprocess-based serve tests unreliable on Windows CI; "
+        "serve is covered by test-frameworks CI job on Windows",
+    )
     def test_serve_huggingface_hub_cli(self):
         """Test mlship serve with HuggingFace Hub model."""
         pytest.importorskip("transformers")

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -1,0 +1,322 @@
+"""Integration tests for mlship CLI commands (serve, benchmark) across all frameworks.
+
+These tests run the actual CLI commands with real model files to ensure
+end-to-end functionality works correctly.
+"""
+
+import json
+import multiprocessing
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+import requests
+
+
+@pytest.fixture(scope="session")
+def sklearn_model_file(tmp_path_factory):
+    """Create sklearn model file for testing."""
+    pytest.importorskip("sklearn")
+
+    from sklearn.ensemble import RandomForestClassifier
+    from sklearn.datasets import make_classification
+    import joblib
+
+    X, y = make_classification(n_samples=100, n_features=4, random_state=42)
+    model = RandomForestClassifier(n_estimators=5, random_state=42)
+    model.fit(X, y)
+
+    model_path = tmp_path_factory.mktemp("models") / "sklearn_model.pkl"
+    joblib.dump(model, model_path)
+
+    return model_path
+
+
+@pytest.fixture(scope="session")
+def pytorch_model_file(tmp_path_factory):
+    """Create PyTorch TorchScript model file for testing."""
+    torch = pytest.importorskip("torch")
+    import torch.nn as nn
+
+    class SimpleModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.fc = nn.Linear(4, 2)
+
+        def forward(self, x):
+            return self.fc(x)
+
+    model = SimpleModel()
+    model.eval()
+    scripted_model = torch.jit.script(model)
+
+    model_path = tmp_path_factory.mktemp("models") / "pytorch_model.pt"
+    torch.jit.save(scripted_model, model_path)
+
+    return model_path
+
+
+@pytest.fixture(scope="session")
+def tensorflow_model_file(tmp_path_factory):
+    """Create TensorFlow model file for testing."""
+    tf = pytest.importorskip("tensorflow")
+    import numpy as np
+
+    X = np.random.rand(100, 4).astype(np.float32)
+    y = np.random.randint(0, 2, 100)
+
+    model = tf.keras.Sequential([
+        tf.keras.layers.Dense(8, activation='relu', input_shape=(4,)),
+        tf.keras.layers.Dense(1, activation='sigmoid')
+    ])
+
+    model.compile(optimizer='adam', loss='binary_crossentropy')
+    model.fit(X, y, epochs=5, verbose=0)
+
+    model_path = tmp_path_factory.mktemp("models") / "tensorflow_model.keras"
+    model.save(model_path)
+
+    return model_path
+
+
+class TestServeCommandCLI:
+    """Test mlship serve command via subprocess."""
+
+    def start_serve_process(self, model_path, port, source="local"):
+        """Start mlship serve command in subprocess."""
+        cmd = ["mlship", "serve", str(model_path), "--port", str(port)]
+        if source == "huggingface":
+            cmd.extend(["--source", "huggingface"])
+
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True
+        )
+        return proc
+
+    def wait_for_server(self, port, timeout=30):
+        """Wait for server to become ready."""
+        url = f"http://127.0.0.1:{port}/health"
+        start = time.time()
+        while time.time() - start < timeout:
+            try:
+                response = requests.get(url, timeout=1)
+                if response.status_code == 200:
+                    return True
+            except requests.exceptions.RequestException:
+                pass
+            time.sleep(0.5)
+        return False
+
+    def test_serve_sklearn_cli(self, sklearn_model_file):
+        """Test mlship serve with sklearn model."""
+        port = 8101
+        proc = self.start_serve_process(sklearn_model_file, port)
+
+        try:
+            assert self.wait_for_server(port, timeout=20), "Server failed to start"
+
+            # Test predict
+            response = requests.post(
+                f"http://127.0.0.1:{port}/predict",
+                json={"features": [1.0, 2.0, 3.0, 4.0]},
+                timeout=5
+            )
+            assert response.status_code == 200
+            assert "prediction" in response.json()
+
+        finally:
+            proc.terminate()
+            proc.wait(timeout=5)
+            if proc.poll() is None:
+                proc.kill()
+
+    def test_serve_pytorch_cli(self, pytorch_model_file):
+        """Test mlship serve with PyTorch model."""
+        port = 8102
+        proc = self.start_serve_process(pytorch_model_file, port)
+
+        try:
+            assert self.wait_for_server(port, timeout=20), "Server failed to start"
+
+            # Test predict
+            response = requests.post(
+                f"http://127.0.0.1:{port}/predict",
+                json={"features": [1.0, 2.0, 3.0, 4.0]},
+                timeout=5
+            )
+            assert response.status_code == 200
+            assert "prediction" in response.json()
+
+        finally:
+            proc.terminate()
+            proc.wait(timeout=5)
+            if proc.poll() is None:
+                proc.kill()
+
+    def test_serve_tensorflow_cli(self, tensorflow_model_file):
+        """Test mlship serve with TensorFlow model."""
+        port = 8103
+        proc = self.start_serve_process(tensorflow_model_file, port)
+
+        try:
+            assert self.wait_for_server(port, timeout=20), "Server failed to start"
+
+            # Test predict
+            response = requests.post(
+                f"http://127.0.0.1:{port}/predict",
+                json={"features": [0.5, 1.2, -0.3, 0.8]},
+                timeout=5
+            )
+            assert response.status_code == 200
+            assert "prediction" in response.json()
+
+        finally:
+            proc.terminate()
+            proc.wait(timeout=5)
+            if proc.poll() is None:
+                proc.kill()
+
+    @pytest.mark.slow
+    def test_serve_huggingface_hub_cli(self):
+        """Test mlship serve with HuggingFace Hub model."""
+        pytest.importorskip("transformers")
+
+        port = 8104
+        model_id = "distilbert-base-uncased-finetuned-sst-2-english"
+        proc = self.start_serve_process(model_id, port, source="huggingface")
+
+        try:
+            # HuggingFace models take longer to load
+            assert self.wait_for_server(port, timeout=60), "Server failed to start"
+
+            # Test predict
+            response = requests.post(
+                f"http://127.0.0.1:{port}/predict",
+                json={"features": "This is a test sentence."},
+                timeout=10
+            )
+            assert response.status_code == 200
+            assert "prediction" in response.json()
+
+        finally:
+            proc.terminate()
+            proc.wait(timeout=5)
+            if proc.poll() is None:
+                proc.kill()
+
+
+class TestBenchmarkCommandCLI:
+    """Test mlship benchmark command via subprocess."""
+
+    def run_benchmark_command(self, model_path, port, requests=20, warmup=3,
+                             source="local", output="json"):
+        """Run mlship benchmark command."""
+        cmd = [
+            "mlship", "benchmark", str(model_path),
+            "--port", str(port),
+            "--requests", str(requests),
+            "--warmup", str(warmup),
+            "--output", output
+        ]
+        if source == "huggingface":
+            cmd.extend(["--source", "huggingface"])
+
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=60
+        )
+        return result
+
+    def test_benchmark_sklearn_cli(self, sklearn_model_file):
+        """Test mlship benchmark with sklearn model."""
+        result = self.run_benchmark_command(sklearn_model_file, port=8201)
+
+        assert result.returncode == 0, f"Benchmark failed: {result.stderr}"
+
+        # Parse JSON output
+        data = json.loads(result.stdout)
+        assert data["framework"] == "sklearn"
+        assert data["benchmark_requests"] == 20
+        assert data["avg_ms"] > 0
+        assert data["throughput_rps"] > 0
+        assert data["min_ms"] <= data["avg_ms"] <= data["max_ms"]
+
+    def test_benchmark_pytorch_cli(self, pytorch_model_file):
+        """Test mlship benchmark with PyTorch model."""
+        result = self.run_benchmark_command(pytorch_model_file, port=8202)
+
+        assert result.returncode == 0, f"Benchmark failed: {result.stderr}"
+
+        data = json.loads(result.stdout)
+        assert data["framework"] == "pytorch"
+        assert data["avg_ms"] > 0
+        assert data["throughput_rps"] > 0
+
+    def test_benchmark_tensorflow_cli(self, tensorflow_model_file):
+        """Test mlship benchmark with TensorFlow model."""
+        result = self.run_benchmark_command(tensorflow_model_file, port=8203)
+
+        assert result.returncode == 0, f"Benchmark failed: {result.stderr}"
+
+        data = json.loads(result.stdout)
+        assert data["framework"] == "tensorflow"
+        assert data["avg_ms"] > 0
+        assert data["throughput_rps"] > 0
+
+    @pytest.mark.slow
+    def test_benchmark_huggingface_hub_cli(self):
+        """Test mlship benchmark with HuggingFace Hub model."""
+        pytest.importorskip("transformers")
+
+        model_id = "distilbert-base-uncased-finetuned-sst-2-english"
+        result = self.run_benchmark_command(
+            model_id, port=8204, requests=10, warmup=2, source="huggingface"
+        )
+
+        assert result.returncode == 0, f"Benchmark failed: {result.stderr}"
+
+        data = json.loads(result.stdout)
+        assert data["framework"] == "huggingface"
+        assert data["avg_ms"] > 0
+        assert data["throughput_rps"] > 0
+
+    def test_benchmark_custom_payload_cli(self, sklearn_model_file):
+        """Test mlship benchmark with custom payload."""
+        cmd = [
+            "mlship", "benchmark", str(sklearn_model_file),
+            "--port", "8205",
+            "--requests", "10",
+            "--warmup", "2",
+            "--output", "json",
+            "--payload", '{"features": [5.0, 6.0, 7.0, 8.0]}'
+        ]
+
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+
+        assert result.returncode == 0, f"Benchmark failed: {result.stderr}"
+
+        data = json.loads(result.stdout)
+        assert data["benchmark_requests"] == 10
+        assert data["avg_ms"] > 0
+
+    def test_benchmark_text_output_cli(self, sklearn_model_file):
+        """Test mlship benchmark with text output format."""
+        result = self.run_benchmark_command(
+            sklearn_model_file, port=8206, requests=10, output="text"
+        )
+
+        assert result.returncode == 0, f"Benchmark failed: {result.stderr}"
+
+        # Check text output contains expected sections
+        assert "BENCHMARK RESULTS" in result.stdout
+        assert "Average:" in result.stdout
+        assert "Throughput:" in result.stdout
+        assert "P50" in result.stdout
+        assert "P95" in result.stdout
+        assert "P99" in result.stdout

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -5,10 +5,8 @@ end-to-end functionality works correctly.
 """
 
 import json
-import multiprocessing
 import subprocess
 import time
-from pathlib import Path
 
 import pytest
 import requests
@@ -66,12 +64,14 @@ def tensorflow_model_file(tmp_path_factory):
     X = np.random.rand(100, 4).astype(np.float32)
     y = np.random.randint(0, 2, 100)
 
-    model = tf.keras.Sequential([
-        tf.keras.layers.Dense(8, activation='relu', input_shape=(4,)),
-        tf.keras.layers.Dense(1, activation='sigmoid')
-    ])
+    model = tf.keras.Sequential(
+        [
+            tf.keras.layers.Dense(8, activation="relu", input_shape=(4,)),
+            tf.keras.layers.Dense(1, activation="sigmoid"),
+        ]
+    )
 
-    model.compile(optimizer='adam', loss='binary_crossentropy')
+    model.compile(optimizer="adam", loss="binary_crossentropy")
     model.fit(X, y, epochs=5, verbose=0)
 
     model_path = tmp_path_factory.mktemp("models") / "tensorflow_model.keras"
@@ -89,12 +89,7 @@ class TestServeCommandCLI:
         if source == "huggingface":
             cmd.extend(["--source", "huggingface"])
 
-        proc = subprocess.Popen(
-            cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True
-        )
+        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
         return proc
 
     def wait_for_server(self, port, timeout=30):
@@ -123,7 +118,7 @@ class TestServeCommandCLI:
             response = requests.post(
                 f"http://127.0.0.1:{port}/predict",
                 json={"features": [1.0, 2.0, 3.0, 4.0]},
-                timeout=5
+                timeout=5,
             )
             assert response.status_code == 200
             assert "prediction" in response.json()
@@ -146,7 +141,7 @@ class TestServeCommandCLI:
             response = requests.post(
                 f"http://127.0.0.1:{port}/predict",
                 json={"features": [1.0, 2.0, 3.0, 4.0]},
-                timeout=5
+                timeout=5,
             )
             assert response.status_code == 200
             assert "prediction" in response.json()
@@ -169,7 +164,7 @@ class TestServeCommandCLI:
             response = requests.post(
                 f"http://127.0.0.1:{port}/predict",
                 json={"features": [0.5, 1.2, -0.3, 0.8]},
-                timeout=5
+                timeout=5,
             )
             assert response.status_code == 200
             assert "prediction" in response.json()
@@ -197,7 +192,7 @@ class TestServeCommandCLI:
             response = requests.post(
                 f"http://127.0.0.1:{port}/predict",
                 json={"features": "This is a test sentence."},
-                timeout=10
+                timeout=10,
             )
             assert response.status_code == 200
             assert "prediction" in response.json()
@@ -212,25 +207,27 @@ class TestServeCommandCLI:
 class TestBenchmarkCommandCLI:
     """Test mlship benchmark command via subprocess."""
 
-    def run_benchmark_command(self, model_path, port, requests=20, warmup=3,
-                             source="local", output="json"):
+    def run_benchmark_command(
+        self, model_path, port, requests=20, warmup=3, source="local", output="json"
+    ):
         """Run mlship benchmark command."""
         cmd = [
-            "mlship", "benchmark", str(model_path),
-            "--port", str(port),
-            "--requests", str(requests),
-            "--warmup", str(warmup),
-            "--output", output
+            "mlship",
+            "benchmark",
+            str(model_path),
+            "--port",
+            str(port),
+            "--requests",
+            str(requests),
+            "--warmup",
+            str(warmup),
+            "--output",
+            output,
         ]
         if source == "huggingface":
             cmd.extend(["--source", "huggingface"])
 
-        result = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            timeout=60
-        )
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
         return result
 
     def test_benchmark_sklearn_cli(self, sklearn_model_file):
@@ -289,12 +286,19 @@ class TestBenchmarkCommandCLI:
     def test_benchmark_custom_payload_cli(self, sklearn_model_file):
         """Test mlship benchmark with custom payload."""
         cmd = [
-            "mlship", "benchmark", str(sklearn_model_file),
-            "--port", "8205",
-            "--requests", "10",
-            "--warmup", "2",
-            "--output", "json",
-            "--payload", '{"features": [5.0, 6.0, 7.0, 8.0]}'
+            "mlship",
+            "benchmark",
+            str(sklearn_model_file),
+            "--port",
+            "8205",
+            "--requests",
+            "10",
+            "--warmup",
+            "2",
+            "--output",
+            "json",
+            "--payload",
+            '{"features": [5.0, 6.0, 7.0, 8.0]}',
         ]
 
         result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -11,7 +11,6 @@ import pytest
 import shutil
 from fastapi.testclient import TestClient
 
-
 # Define PyTorch model at module level (can't pickle local classes)
 try:
     import torch.nn as nn

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -6,7 +6,6 @@ from fastapi.testclient import TestClient
 
 from mlship.pipeline import Pipeline
 
-
 # Define PyTorch model at module level (can't pickle local classes)
 try:
     import torch.nn as nn


### PR DESCRIPTION
## Summary

- Adds `mlship benchmark` CLI command that starts a server in the background, measures cold start latency, runs warmup and benchmark requests, and reports performance metrics (avg, min, p50, p95, p99, max latency + throughput)
- Supports all frameworks (sklearn, PyTorch, TensorFlow, HuggingFace) with auto-generated test payloads
- Includes JSON output format (`--output json`) for CI/CD integration
- Updated documentation across ARCHITECTURE.md, README.md, and WHY_MLSHIP.md

Closes #1

## Test plan

- [x] Unit tests for benchmark command (6 tests in `test_benchmark.py`)
- [x] Integration tests across all 4 frameworks (10 tests in `test_cli_integration.py`)
- [x] All 63 existing tests pass with no regressions
- [x] Manually verified with sklearn, PyTorch, TensorFlow, and HuggingFace models